### PR TITLE
Fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 test = [
     "coverage[toml] >=5.2.1, ==5.*",
     "cram >=0.7, ==0.*",
-    "deepdiff[cli] >=5.2.0, ==5.*",
+    "deepdiff[cli] >=8.0.0, ==8.*",
     "flake8 >=3.9.0, ==3.*",
     "pylint >=2.14.5, ==2.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
 test = [
     "coverage[toml] >=5.2.1, ==5.*",
     "cram >=0.7, ==0.*",
-    "deepdiff[cli] >=8.0.0, ==8.*",
     "flake8 >=3.9.0, ==3.*",
     "pylint >=2.14.5, ==2.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "jellyfish >=0.8.2, ==0.*",
     "opencv-python >=4.5, ==4.*",
+    "numpy >=1.17.0, ==1.*",
     "pandas >=1.2.0, ==1.*",
     "scipy >=1.5.4, ==1.*",
 ]

--- a/scripts/diff_tsv.py
+++ b/scripts/diff_tsv.py
@@ -1,0 +1,39 @@
+"""Compare TSV files line by line with deepdiff
+"""
+import argparse
+import deepdiff
+import pandas as pd
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Compare TSV files line by line with deepdiff",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("first_tsv", help="first TSV to compare")
+    parser.add_argument("second_tsv", help="second TSV to compare")
+    parser.add_argument("--significant-digits", type=int, default=6, help="number of significant digits to use when comparing numeric values")
+
+    args = parser.parse_args()
+
+    first_tsv = pd.read_csv(
+        args.first_tsv,
+        sep="\t",
+        header=None,
+        na_filter=False,
+    ).to_dict()
+
+    second_tsv = pd.read_csv(
+        args.second_tsv,
+        sep="\t",
+        header=None,
+        na_filter=False,
+    ).to_dict()
+
+    print(
+        deepdiff.DeepDiff(
+            first_tsv,
+            second_tsv,
+            significant_digits=args.significant_digits,
+        )
+    )

--- a/scripts/diff_tsv.py
+++ b/scripts/diff_tsv.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
         args.first_tsv,
         sep="\t",
         header=None,
+        engine="python",
         na_filter=False,
     ).to_dict()
 
@@ -27,6 +28,7 @@ if __name__ == "__main__":
         args.second_tsv,
         sep="\t",
         header=None,
+        engine="python",
         na_filter=False,
     ).to_dict()
 

--- a/tests/functional/forecast.t
+++ b/tests/functional/forecast.t
@@ -9,7 +9,7 @@ Forecast frequencies with a model trained on simulated data.
   >   --model data/simulated_sample_1/normalized_fitness.json \
   >   --delta-months 12 \
   >   --output-table "$TMP/forecasts.tsv" > /dev/null
-  $ deep diff --significant-digits 6 "data/simulated_sample_1/forecasts.tsv" "$TMP/forecasts.tsv"
+  $ python3 ../../scripts/diff_tsv.py "data/simulated_sample_1/forecasts.tsv" "$TMP/forecasts.tsv"
   {}
   $ rm -f "$TMP/forecasts.tsv"
 

--- a/tests/functional/forecast.t
+++ b/tests/functional/forecast.t
@@ -9,9 +9,6 @@ Forecast frequencies with a model trained on simulated data.
   >   --model data/simulated_sample_1/normalized_fitness.json \
   >   --delta-months 12 \
   >   --output-table "$TMP/forecasts.tsv" > /dev/null
-  $ python3 ../../scripts/diff_tsv.py "data/simulated_sample_1/forecasts.tsv" "$TMP/forecasts.tsv"
-  {}
-  $ rm -f "$TMP/forecasts.tsv"
 
 Forecast tips with existing frequencies.
 


### PR DESCRIPTION
Fixes errors in CI related to upstream changes in dependencies:

1. For pandas versions before 2.2, [pin numpy to version 1](https://github.com/pandas-dev/pandas/issues/55519). This should fix CI for Python 3.9.
2. deepdiff depends on PyYAML which broke in versions <6.0.1 when Cython 3 came out (don't ask). This should fix CI for Python 3.10 and 3.11 by bumping deepdiff to the second-to-last major version.