### PR TITLE
Move OpenCV to an optional dependency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[test]
+        python -m pip install .[full,test]
     - name: Lint with flake8
       run: |
         # stop the build if there are any warnings or errors.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 2.0.0
+
+### Major changes
+
+- Make [OpenCV](https://pypi.org/project/opencv-python/) an optional dependency, simplifying installation requirements for forecasting from an existing model. This change requires users to specify the "full" package version at installation to get support for model fitting. [#4](https://github.com/blab/popcast/pull/4) (@huddlej)
+
 ## 1.1.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ See the methods of [Huddleston et al. 2020](https://doi.org/10.7554/eLife.60067)
 
 ## Install
 
+For a full installation with the OpenCV package that's required for model fitting, specify the "full" package dependencies.
+
 ``` bash
-python3 -m pip install popcast
+python -m pip install 'popcast[full]'
+```
+
+For a smaller installation that only supports forecasting with an existing model, omit the optional package dependency.
+
+``` bash
+python -m pip install popcast
 ```
 
 ## Usage
@@ -30,7 +38,7 @@ popcast fit \
 ### Install locally
 
 ``` bash
-python3 -m pip install ".[test]"
+python -m pip install '.[full,test]'
 ```
 
 ### Lint and run tests
@@ -52,17 +60,17 @@ cram --shell=/bin/bash tests/
 Install or upgrade publishing tools.
 
 ``` bash
-python3 -m pip install --upgrade build twine
+python -m pip install --upgrade build twine
 ```
 
 Build the distribution packages.
 
 ``` bash
-python3 -m build
+python -m build
 ```
 
 Upload the distribution packages.
 
 ``` bash
-python3 -m twine upload dist/*
+python -m twine upload dist/*
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,15 @@ classifiers = [
 
 dependencies = [
     "jellyfish >=0.8.2, ==0.*",
-    "opencv-python >=4.5, ==4.*",
     "numpy >=1.17.0, ==1.*",
     "pandas >=1.2.0, ==1.*",
     "scipy >=1.5.4, ==1.*",
 ]
 
 [project.optional-dependencies]
+full = [
+    "opencv-python >=4.5, ==4.*",
+]
 test = [
     "coverage[toml] >=5.2.1, ==5.*",
     "cram >=0.7, ==0.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "popcast"
-version = "1.1.0"
+version = "2.0.0"
 authors = [
   { name="John Huddleston", email="huddlej@gmail.com" },
 ]

--- a/src/popcast/__init__.py
+++ b/src/popcast/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """John Huddleston"""
 __email__ = 'huddlej@gmail.com'
-__version__ = '1.1.0'
+__version__ = '2.0.0'

--- a/src/popcast/fit.py
+++ b/src/popcast/fit.py
@@ -1,6 +1,5 @@
 """Fit a model for the given data using the requested predictors and evaluate the model by time series cross-validation.
 """
-import cv2
 import json
 import numpy as np
 import pandas as pd
@@ -418,6 +417,12 @@ class DistanceExponentialGrowthModel(ExponentialGrowthModel):
             error between estimated values using the given coefficients and
             input data and the observed values
         """
+        try:
+            import cv2
+        except ImportError:
+            print("Failed to import cv2 package required for model fitting. Install popcast with OpenCV using \"python -m pip install 'popcast[full]'\".", file=sys.stderr)
+            sys.exit(1)
+
         # Estimate target values.
         y_hat = self.predict(X, coefficients)
 


### PR DESCRIPTION
Enables a "slim" installation of the package by making OpenCV an optional dependency. Users can install OpenCV with the new "full" variant of the package to get support for model fitting. The default installation will only support forecasting from an existing model. Since this latter scenario is the most common use case for popcast and requires a substantially smaller footprint on disk, this default is what we'll want for environments like the Nextstrain Docker image.